### PR TITLE
Issue with model.get not a function

### DIFF
--- a/addon/mixins/route-history.js
+++ b/addon/mixins/route-history.js
@@ -12,7 +12,7 @@ export default Ember.Mixin.create({
 
     if (this.get('isSingleResource')) {
       var model = this.modelFor(this.get('currentPath'));
-      if (Ember.isPresent(model)) {
+      if (Ember.isPresent(model) && typeof model.get === "function") {
         transition.set('params', model.get('slug') || model.get('id'));
       }
     }


### PR DESCRIPTION
Thanks for this addon! 

I had an issue with activeRoute calling model.get() if model is present. For a model that is an Ember.RSVP.hash model, for example, this was failing. I added a line here to check if model has the get() function.

I see that you have filed an issue about this already, if this seems like a good solution, great.
