### PR TITLE
Add new parentRoute mixin to addon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Ember-cli-history-mixin [![Build Status](https://travis-ci.org/alexanderjeurissen/ember-cli-history-mixin.svg)](https://travis-ci.org/alexanderjeurissen/ember-cli-history-mixin)
 
-Ember-cli-history-mixin is a mixin that provides forward and backward actions
-to an Ember-CLI application which in turn either navigate one page back or one
-page forward.
-
+Ember-cli-history-mixin is a mixin that provides `goForward` `gobackward` and
+`goToParent` actions to an Ember-CLI application which in turn either navigate
+one page back or one page forward or in the case of the `goToParent` action
+navigate to the parent route where the hierarchy of the router is used as
+guideline.
 
 Seeing as there is no native ember functionality for keeping track of `history`
 most people fall back to using the global `window.history` object.
@@ -21,9 +22,25 @@ and `goForward` action and therefore decided to write my own.
 
 `ember install:addon ember-cli-history-mixin`
 
-## Usage
-This ember-cli addon provides a route-history mixin that needs to be injected in
-the application-route in order to keep track of all route changes.
+## Which mixin is right for me? `routeHistory` or `parentRoute`?
+The *routeHistory mixin* hooks into the `willTransition` and `didTransition`
+methods of the application route in order to listen to route changes. The
+*parentRoute mixin* calculates the nearest parent route based on the current
+route and uses the hierarchy of the router object.
+
+When you need a mixin that keeps track of the history of your application and
+you need both `goForward` and `goBack` actions then I would suggest you use the
+*routeHistory mixin* however when you don't need to actively monitor the history
+of your application and you rather want `cancel` buttons that navigate to the
+nearest parent route then the *parentRoute mixin* will better suit your needs
+and is also less resource intensive.
+
+The mixins don't conflict with each other so they can be used at the same time.
+
+## Using the `RouteHistory` mixin
+This ember-cli addon provides a `routeHistory mixin` that actively monitors the
+route changes in your application because of that it needs to be injected in the
+application-route in order to keep track of all route changes.
 
 ```javascript
 import Ember from 'ember';
@@ -53,6 +70,46 @@ App.BackButtonComponent = Ember.Component.extend({
   }
 });
 ```
+
+## Using the `ParentRoute` mixin
+In addition to the `routeHistory mixin` This ember-cli addon provides a
+`parentRoute mixin` that is less resource intensive and computes the nearest
+parent route based on the hierarchy of the router object.
+
+Because it doesn't actively monitor the route history, one may choose to only
+inject the mixin in routes that need the `goToParent` action, however if you
+want to use the action application-wide then it's advised to inject the mixin in
+the application route.
+
+```javascript
+import Ember from 'ember';
+import ParentRouteMixin from 'ember-cli-history-mixin/mixins/parent-route';
+
+export default Ember.Route.extend(ParentRouteMixin, {
+  //your application-route content
+});
+```
+
+This allows other parts of the application to send the `goToParent` action
+which will be captured in the mixin.
+
+###templates:
+
+```handlebars
+<button id="goBackBtn" {{action "goBack"}}>Back</button>
+<button id="goForwardBtn" {{action "goForward"}}>Forward</button>
+```
+
+###components:
+
+```javascript
+App.BackButtonComponent = Ember.Component.extend({
+  click: function() {
+    this.sendAction('goBack');
+  }
+});
+```
+
 ## Contribution guidelines:
 
 ### Pulling the project in order to modify or Contribute

--- a/addon/mixins/parent-route.js
+++ b/addon/mixins/parent-route.js
@@ -1,0 +1,38 @@
+import Ember from "ember";
+
+export default Ember.Mixin.create({
+  fetchParentRoute: function () {
+    var Routes = Ember.A(this.router.router.currentHandlerInfos);
+    var currentRouteName = this.get('controller.currentRouteName');
+    var currentRoute = Routes.findBy('name', currentRouteName);
+    var currentRouteIndex = Routes.indexOf(currentRoute);
+    var parentRoute = Routes[currentRouteIndex - 1];
+    var ROUTE = 0, MODEL = 1;
+
+    var targetRoute = [2];
+    targetRoute[ROUTE] = parentRoute.name;
+    targetRoute[MODEL] = parentRoute.context;
+
+    if (currentRoute.name.match(/\w+\.index/) &&
+      targetRoute[ROUTE] === currentRoute.name.split('.')[0]) {
+      targetRoute[ROUTE] = Ember.Inflector.inflector.pluralize(
+        targetRoute[ROUTE]
+      );
+      targetRoute.splice(MODEL, 1);
+    } else if (Ember.isBlank(targetRoute[MODEL])) {
+      targetRoute.splice(MODEL, 1);
+    }
+
+    return targetRoute;
+  },
+
+  actions: {
+    goToParentRoute: function () {
+      this.get('controller').transitionToRoute.apply(
+        this.get('controller'),
+        this.fetchParentRoute()
+      );
+    }
+  }
+});
+

--- a/tests/acceptance/parent-route-test.js
+++ b/tests/acceptance/parent-route-test.js
@@ -1,0 +1,100 @@
+/* jshint expr:true */
+import Ember from "ember";
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+var App;
+
+module('parentRoute integration specs', {
+  beforeEach: function () {
+    App = startApp();
+    visit('/');
+  },
+
+  afterEach: function () {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('goBack to `index` from `posts`', function (assert) {
+  visit('/posts');
+  click('button#goBackToParentBtn');
+
+  andThen(function () {
+    assert.equal(currentRouteName(), 'index');
+  });
+});
+
+test('goBack to `posts` from `post.index`', function (assert) {
+  visit('/posts/1');
+  click('button#goBackToParentBtn');
+
+  andThen(function () {
+    assert.equal(currentRouteName(), 'posts');
+  });
+});
+
+test('goBack to `post.index` from `post.edit`', function (assert) {
+  visit('/posts/1/edit');
+  click('button#goBackToParentBtn');
+
+  andThen(function () {
+    assert.equal(currentRouteName(), 'post.index');
+  });
+});
+
+test('when transitioning back from `posts` to `index`', function (assert) {
+  visit('/');
+  click('a:contains("posts")');
+  click('button#goBackToParentBtn');
+  andThen(function () {
+    assert.equal(currentRouteName(), 'index');
+  });
+});
+
+test('when transitioning back from `post.index` to `posts`', function (assert) {
+  visit('/');
+  click('a:contains("posts")');
+  click('a:contains("First")');
+  click('button#goBackToParentBtn');
+  andThen(function () {
+    assert.equal(currentRouteName(), 'posts');
+  });
+});
+
+test('when transitioning back from `post.edit` to `post.index`', function (assert) {
+  visit('/');
+  click('a:contains("posts")');
+  click('a:contains("First")');
+  click('a:contains("edit")');
+  click('button#goBackToParentBtn');
+  andThen(function () {
+    assert.equal(currentRouteName(), 'post.index');
+  });
+});
+
+test('when transitioning from `post.edit` back to `post.index`' +
+  ' back to `posts` and back to `index`', function (assert) {
+    visit('/');
+    click('a:contains("posts")');
+    click('a:contains("First")');
+    click('a:contains("edit")');
+    click('button#goBackToParentBtn');
+    click('button#goBackToParentBtn');
+    click('button#goBackToParentBtn');
+
+    andThen(function () {
+      assert.equal(currentRouteName(), 'index');
+    });
+  });
+
+test('when visiting the info and about route ' +
+  'and then navigating back to the info route', function (assert) {
+    visit('/');
+    click('a:contains("Info")');
+    click('a:contains("About")');
+    click('button#goBackToParentBtn');
+    andThen(function () {
+      assert.equal(currentRouteName(), 'index');
+    });
+  });
+

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
 import RouteHistoryMixin from 'ember-cli-history-mixin/mixins/route-history';
+import ParentRouteMixin from 'ember-cli-history-mixin/mixins/parent-route';
 
-export default Ember.Route.extend(RouteHistoryMixin, {});
+export default Ember.Route.extend(RouteHistoryMixin, ParentRouteMixin, {});


### PR DESCRIPTION
In addition to the `routeHistory mixin` This ember-cli addon provides a
`parentRoute mixin` that is less resource intensive and computes the nearest
parent route based on the hierarchy of the router object.
